### PR TITLE
Fixes #6: Removes Deprecated Bundle Name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 from sugar3.activity import bundlebuilder
-bundlebuilder.start("Bridge")
+bundlebuilder.start()


### PR DESCRIPTION
Since @ccr4b does not seem to be working on this issue, I guess I'll take his place.

- I removed the bundle name in the `start()` in setup.py according to the error message (after all `bundlebuilder.start()` does not take in any arguments). 

- I then tested the `dist_source` command and there seems to be no problem as the tar package generates without any errors. I also ran other commands such as `genpot` and `dev` and no errors pop up, with the POT file being generated without incident.

- Next, I tested the activity and it seems to be working without flaws.

- I even tested the setup.py file using flake8 and no errors occur.

So I think that the only thing to fix here is just removing the bundle name. After all, there was no bundle name in the past when I reviewed the history of the file.