### PR TITLE
Made the toolbar show the currently selected tool

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -32,6 +32,7 @@ from sugar3.activity.activity import Activity
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.graphics.toolbutton import ToolButton
+from sugar3.graphics.radiotoolbutton import RadioToolButton
 from sugar3.graphics.toggletoolbutton import ToggleToolButton
 from sugar3.graphics.style import GRID_CELL_SIZE
 from sugar3.activity.widgets import ActivityButton
@@ -71,8 +72,13 @@ class BridgeActivity(Activity):
 
         self.blocklist = []
         self.radioList = {}
-        for c in tools.allTools:
-            button = ToolButton(c.icon)
+        for i,c in enumerate(tools.allTools):
+            if i == 0:
+                button = RadioToolButton(group=None)
+                firstbutton = button
+            else:
+                button = RadioToolButton(group=firstbutton)
+            button.set_icon_name(c.icon)
             button.set_tooltip(_(c.toolTip))
             button.connect('clicked', self.radioClicked)
             toolbar_box.toolbar.insert(button, -1)

--- a/activity.py
+++ b/activity.py
@@ -70,8 +70,13 @@ class BridgeActivity(Activity):
         toolbar_box.toolbar.insert(activity_button, 0)
         activity_button.show()
 
+        seperator = Gtk.SeparatorToolItem()
+        toolbar_box.toolbar.insert(seperator, -1)
+        seperator.show()
+
         self.blocklist = []
         self.radioList = {}
+
         for i,c in enumerate(tools.allTools):
             if i == 0:
                 button = RadioToolButton(group=None)
@@ -84,6 +89,10 @@ class BridgeActivity(Activity):
             toolbar_box.toolbar.insert(button, -1)
             button.show()
             self.radioList[button] = c.name
+
+        seperator = Gtk.SeparatorToolItem()
+        toolbar_box.toolbar.insert(seperator, -1)
+        seperator.show()
 
         self._pause = ToggleToolButton('media-playback-pause')
         self._pause.set_tooltip(_('Pause'))


### PR DESCRIPTION
## Overview
I have turned the toolbar buttons at the top of the activity so that we know what toolbar item has been selected

## Description
I have changed the `ToolButton`s to `RadioToolButton`s 

## Screenshots
<img width="684" alt="Screenshot_20230215_055928" src="https://user-images.githubusercontent.com/114365550/219029747-64b35b58-14de-466a-88f1-9e08a2c45e49.png">

> Before changes: The screenshot shows the grab tool being selected but there is no indication as to it being selected

![WhatsApp Image 2023-02-15 at 17 53 20](https://user-images.githubusercontent.com/114365550/219029494-ca9d096a-4573-4dcf-b93c-f078583ec55e.jpg)
> After the changes : In the above screenshot the Grab tool is selected and is shown clearly 